### PR TITLE
Fix session lifetime parsing bug

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,9 +9,15 @@ def create_app(config_class=Config):
     app = Flask(__name__)
     app.config.from_object(config_class)
 
-    # Ensure permanent session lifetime is set from config
-    if isinstance(app.config.get('PERMANENT_SESSION_LIFETIME'), (int, float)):
-         app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(seconds=app.config['PERMANENT_SESSION_LIFETIME'])
+    # Ensure permanent session lifetime is correctly parsed
+    lifetime = app.config.get('PERMANENT_SESSION_LIFETIME')
+    # Environment variables are always strings. Allow numeric strings by
+    # converting them to integers before building the timedelta.
+    if isinstance(lifetime, str) and lifetime.isdigit():
+        lifetime = int(lifetime)
+
+    if isinstance(lifetime, (int, float)):
+        app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(seconds=lifetime)
 
 
     db.init_app(app)


### PR DESCRIPTION
## Summary
- handle PERMANENT_SESSION_LIFETIME environment variable when it is a string

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686524bf8708832480c0e865a93ef482